### PR TITLE
Http netty async listeners

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpServiceContextImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpServiceContextImpl.java
@@ -112,6 +112,7 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http2.DefaultHttp2Headers;
 import io.netty.handler.codec.http2.Http2Connection;
 import io.netty.handler.codec.http2.Http2Headers;
@@ -3297,6 +3298,7 @@ public abstract class HttpServiceContextImpl implements HttpServiceContext, FFDC
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc, "sendFullOutgoing : No buffers to write ");
             }
+            this.nettyContext.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT);
         }
         this.nettyContext.channel().flush();
         MSP.log("set message sent");

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpServiceContextImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpServiceContextImpl.java
@@ -3298,7 +3298,9 @@ public abstract class HttpServiceContextImpl implements HttpServiceContext, FFDC
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc, "sendFullOutgoing : No buffers to write ");
             }
-            this.nettyContext.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT);
+            //this.nettyContext.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT);
+            this.nettyContext.channel().write(new LastStreamSpecificHttpContent(Integer.valueOf(nettyResponse.headers().get(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(),
+                            "-1"))));
         }
         this.nettyContext.channel().flush();
         MSP.log("set message sent");

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpDispatcherLink.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpDispatcherLink.java
@@ -67,7 +67,6 @@ import com.ibm.wsspi.http.ee8.Http2InboundConnection;
 import com.ibm.wsspi.tcpchannel.TCPConnectionContext;
 
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
@@ -219,6 +218,8 @@ public class HttpDispatcherLink extends InboundApplicationLink implements HttpIn
         }
 
         if (usingNetty) {
+
+            //No Change
 
             //register what the close will do, let the close be handled by
             //the persist handler

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyBaseMessage.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyBaseMessage.java
@@ -14,6 +14,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -450,13 +451,27 @@ public class NettyBaseMessage implements HttpBaseMessage {
 
     @Override
     public List<HttpCookie> getAllCookies() {
-        return null;
+        List<HttpCookie> list = new LinkedList<HttpCookie>();
+        getAllCookies(HttpHeaderKeys.HDR_SET_COOKIE, list);
+        getAllCookies(HttpHeaderKeys.HDR_SET_COOKIE2, list);
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "getAllCookies: Found " + list.size() + " instances");
+        }
+        return list;
     }
 
     @Override
     public List<HttpCookie> getAllCookies(String name) {
 
-        return null;
+        List<HttpCookie> list = new LinkedList<HttpCookie>();
+        if (null != name) {
+            getAllCookies(name, HttpHeaderKeys.HDR_SET_COOKIE, list);
+            getAllCookies(name, HttpHeaderKeys.HDR_SET_COOKIE2, list);
+        }
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "getAllCookies: Found " + list.size() + " instances of " + name);
+        }
+        return list;
     }
 
     /**

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyRequestMessage.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyRequestMessage.java
@@ -673,5 +673,18 @@ public class NettyRequestMessage extends NettyBaseMessage implements HttpRequest
 
         return list;
     }
+    
+    @Override
+    public HttpCookie getCookie(String name) {
+        if (null == name) {
+            return null;
+        }
+        HttpCookie cookie = getCookie(name, HttpHeaderKeys.HDR_COOKIE);
+        if (null == cookie) {
+            cookie = getCookie(name, HttpHeaderKeys.HDR_COOKIE2);
+        }
+        // Note: return a clone to avoid corruption by the caller
+        return (null == cookie) ? null : cookie.clone();
+    }
 
 }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyResponseMessage.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyResponseMessage.java
@@ -132,8 +132,17 @@ public class NettyResponseMessage extends NettyBaseMessage implements HttpRespon
 
     @Override
     public boolean isBodyAllowed() {
-        //Compatibility to implement the interface, processing is delegated to the Netty server codec
-        return false;
+        if (super.isBodyAllowed()) {
+
+            // sending a body with the response is not valid for a HEAD request
+            //TODO:Set false if request is HEAD
+
+            // if that worked, then check the status code flag
+            //can status code send body?
+        }
+
+        // no body allowed on this message
+        return true;
     }
 
     @Override

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/BufferEncoder.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/BufferEncoder.java
@@ -21,61 +21,75 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.handler.codec.http2.HttpToHttp2ConnectionHandler;
 import io.netty.handler.codec.http2.LastStreamSpecificHttpContent;
+import io.netty.handler.codec.http2.StreamSpecificHttpContent;
 import io.netty.handler.stream.ChunkedInput;
 
 /**
- *
+ * A Netty message encoder for encoding message data into HTTP responses.
+ * This encoder handles both HTTP/1.1 and HTTP/2, choosing the appropriate encoding method accordingly.
  */
 public class BufferEncoder extends MessageToMessageEncoder<AbstractMap.SimpleEntry<Integer, WsByteBuffer>> {
 
     private long bytesWritten = 0;
 
+    /**
+     * Encodes message data into HTTP responses.
+     *
+     * @param context The channel handler context.
+     * @param pair    A key-value pair containing the stream ID and response message.
+     * @param out     The list of objects to which the encoded data should be added.
+     * @throws Exception If an error occurs during encoding.
+     */
     @Override
     public void encode(ChannelHandlerContext context, AbstractMap.SimpleEntry<Integer, WsByteBuffer> pair, List<Object> out) throws Exception {
-        //out.writeBytes(message.getWrappedByteBuffer());
+
         Integer streamId = pair.getKey();
         WsByteBuffer message = pair.getValue();
 
-        boolean doLastHttpContent = Boolean.FALSE;
+        boolean doLastHttpContent = false;
+
+        bytesWritten += message.remaining();
 
         MSP.log("Encode: bytes written: " + bytesWritten + ", bytes to write: " + message.remaining());
-        this.bytesWritten += message.remaining();
-
         System.out.println("Encode Got content: " + WsByteBufferUtils.asString(message));
 
         if (context.channel().hasAttr(NettyHttpConstants.CONTENT_LENGTH)) {
-
-            // TODO Should this be <= or >=?
-            // doLastHttpContent = context.channel().attr(NettyHttpConstants.CONTENT_LENGTH).get() <= bytesWritten;
             doLastHttpContent = context.channel().attr(NettyHttpConstants.CONTENT_LENGTH).get() == bytesWritten;
-            System.out.println("Has content lenght! Bytest Written: " + bytesWritten + " contentLength: " + context.channel().attr(NettyHttpConstants.CONTENT_LENGTH).get());
-
+            System.out.println("Has content length! Bytes Written: " + bytesWritten + " Content Length: " + context.channel().attr(NettyHttpConstants.CONTENT_LENGTH).get());
         }
 
-        //if (context.channel().hasAttr(NettyHttpConstants.CHUNCKED_ENCODING) && context.channel().attr(NettyHttpConstants.CHUNCKED_ENCODING).get()
-        //              || !doLastHttpContent) {
-        // Do Chunked Input
-        // Checked adding counter for bytes written when in Chunked encoding
-//            out.add(new HttpChunkedInput(message.getWrappedByteBuffer()));
-        if (!doLastHttpContent) {
+        if (isHttp2(context) && !doLastHttpContent) {
+            // For HTTP/2 and not the last content, use StreamSpecificHttpContent
+            System.out.println("Sending HTTP/2 content");
+            out.add(new StreamSpecificHttpContent(streamId, Unpooled.wrappedBuffer(message.getWrappedByteBuffer())));
+        } else if (!doLastHttpContent) {
+            // For HTTP/1.1 and not the last content, use ChunkedInput
             System.out.println("Sending chunked input");
-//            out.add(new DefaultHttpContent(Unpooled.wrappedBuffer(message.getWrappedByteBuffer())));
-            // out.add(new StreamSpecificHttpContent(streamId, Unpooled.wrappedBuffer(message.getWrappedByteBuffer())));
-
             ChunkedInput<ByteBuf> chunkedInput = new WsByteBufferChunkedInput(message);
             MSP.log("Should be writing a chunk of size: " + chunkedInput.length());
-
             context.writeAndFlush(chunkedInput);
-
         } else {
-            // Do Content Length
-            // TODO Check if should be full http message
-//            out.add(new DefaultHttpContent(Unpooled.wrappedBuffer(message.getWrappedByteBuffer())));
+            // For HTTP/1.1 or HTTP/2 when doLastHttpContent is true, use LastStreamSpecificHttpContent
+
             System.out.println("Sending last http content");
-//            out.add(new DefaultLastHttpContent(Unpooled.wrappedBuffer(message.getWrappedByteBuffer())));
             out.add(new LastStreamSpecificHttpContent(streamId, Unpooled.wrappedBuffer(message.getWrappedByteBuffer())));
+
         }
+    }
+
+    /**
+     * Determines whether HTTP/2 is being utilized based on the context.
+     *
+     * @param context The channel handler context.
+     * @return True if HTTP/2 is detected, false otherwise.
+     */
+
+    private boolean isHttp2(ChannelHandlerContext context) {
+        HttpToHttp2ConnectionHandler http2Handler = context.pipeline().get(HttpToHttp2ConnectionHandler.class);
+
+        return (http2Handler != null) ? true : false;
     }
 
 }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/ChunkSizeLoggingHandler.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/ChunkSizeLoggingHandler.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.http.netty.pipeline;
+
+import com.ibm.ws.http.netty.MSP;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+
+/**
+ *
+ */
+public class ChunkSizeLoggingHandler extends ChannelOutboundHandlerAdapter {
+
+    @Override
+    public void write(ChannelHandlerContext context, Object msg, ChannelPromise promise) throws Exception {
+        if (msg instanceof ByteBuf) {
+            ByteBuf chunk = (ByteBuf) msg;
+            int chunkSize = chunk.readableBytes();
+            MSP.log("Chunk size: " + chunkSize + " bytes");
+        }
+
+        super.write(context, msg, promise);
+    }
+
+}

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/HttpPipelineInitializer.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/HttpPipelineInitializer.java
@@ -43,6 +43,7 @@ import io.netty.handler.codec.http2.CleartextHttp2ServerUpgradeHandler;
 import io.netty.handler.codec.http2.CleartextHttp2ServerUpgradeHandler.PriorKnowledgeUpgradeEvent;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
+import io.netty.handler.stream.ChunkedWriteHandler;
 import io.openliberty.netty.internal.ChannelInitializerWrapper;
 import io.openliberty.netty.internal.exception.NettyException;
 import io.openliberty.netty.internal.tls.NettyTlsProvider;
@@ -311,7 +312,8 @@ public class HttpPipelineInitializer extends ChannelInitializerWrapper {
         if (!isHttp2)
             pipeline.addBefore(HTTP_DISPATCHER_HANDLER_NAME, HTTP_KEEP_ALIVE_HANDLER_NAME, new HttpServerKeepAliveHandler());
         pipeline.addBefore(HTTP_DISPATCHER_HANDLER_NAME, null, new HttpObjectAggregator(64 * 1024));
-//        pipeline.addBefore(HTTP_DISPATCHER_HANDLER_NAME, null, new ChunkedWriteHandler());
+        pipeline.addBefore(HTTP_DISPATCHER_HANDLER_NAME, null, new ChunkSizeLoggingHandler());
+        pipeline.addBefore(HTTP_DISPATCHER_HANDLER_NAME, null, new ChunkedWriteHandler());
         // if (httpConfig.useAutoCompression()) {
         //   pipeline.addLast(new NettyHttpContentCompressor());
         //}

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/WsByteBufferChunkedInput.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/WsByteBufferChunkedInput.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.http.netty.pipeline;
+
+import java.util.Queue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import com.ibm.wsspi.bytebuffer.WsByteBuffer;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.stream.ChunkedInput;
+
+/**
+ *
+ */
+public class WsByteBufferChunkedInput implements ChunkedInput<ByteBuf> {
+
+    private final Queue<ByteBuf> chunks = new LinkedBlockingQueue<>();
+    private boolean endOfInput = Boolean.FALSE;
+
+    public WsByteBufferChunkedInput(WsByteBuffer buffer) {
+        while (buffer.hasRemaining()) {
+            int chunkSize = Math.min(buffer.remaining(), 8192);
+            byte[] chunkData = new byte[chunkSize];
+            buffer.get(chunkData);
+            chunks.add(Unpooled.wrappedBuffer(chunkData));
+        }
+        endOfInput = Boolean.TRUE;
+    }
+
+    @Override
+    public void close() throws Exception {
+        //TODO: release buffer?
+    }
+
+    @Override
+    public boolean isEndOfInput() throws Exception {
+        return endOfInput;
+    }
+
+    @Override
+    public long length() {
+        return -1;
+    }
+
+    @Override
+    public long progress() {
+        return 0; //No need to track progress
+    }
+
+    @Override
+    public ByteBuf readChunk(ChannelHandlerContext arg0) throws Exception {
+        return chunks.poll();
+    }
+
+    @Override
+    public ByteBuf readChunk(ByteBufAllocator arg0) throws Exception {
+        // TODO Auto-generated method stub
+        return chunks.poll();
+    }
+
+}

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/inbound/HttpDispatcherHandler.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/inbound/HttpDispatcherHandler.java
@@ -37,6 +37,8 @@ public class HttpDispatcherHandler extends SimpleChannelInboundHandler<FullHttpR
 
     public HttpDispatcherHandler(HttpChannelConfig config) {
 
+        super(false);
+
         Objects.requireNonNull(config);
         this.config = config;
     }

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/AsyncWriteListenerHttpUnit.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/AsyncWriteListenerHttpUnit.java
@@ -18,8 +18,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Objects;
@@ -96,6 +94,7 @@ public class AsyncWriteListenerHttpUnit {
 
         // Start the server and use the class name so we can find logs easily.
         server.startServer(AsyncWriteListenerHttpUnit.class.getSimpleName() + ".log");
+        server.waitForStringInLogUsingMark("CWWKO0219I*");
 
         if (FATSuite.isWindows) {
             FATSuite.setDynamicTrace(server, "*=info=enabled");
@@ -623,118 +622,118 @@ public class AsyncWriteListenerHttpUnit {
      *
      *                       This method will not take care of println
      */
-//    private int connectSendExpectDataSizeInResponse(int ExpectdResponseSize, String testtocall) throws Exception {
-//
-//        String URLString = null;
-//        if (testtocall.equals("TestWriteFromFilter_AftersetWL")) {
-//            URLString = "http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + WRITE_LISTENER__FILTER_SERVLET_URL;
-//        } else
-//            URLString = "http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + WRITE_LISTENER_SERVLET_URL;
-//
-//        URL url = null;
-//        HttpURLConnection con = null;
-//        StringBuilder sb = new StringBuilder();
-//
-//        LOG.info("\n Request URL : " + URLString);
-//
-//        //char[] buffer = new char[1000];
-//
-//        url = new URL(URLString);
-//        con = (HttpURLConnection) url.openConnection();
-//        con.setRequestMethod("POST");
-//        con.setRequestProperty("TestToCall", testtocall);
-//        con.setRequestProperty("ContentSizeSent", Integer.toString(ExpectdResponseSize));
-//        con.setDoOutput(true);
-//        con.setDoInput(true);
-//        con.connect();
-//
-//        LOG.info("Start reading the response.  Expected response size : " + ExpectdResponseSize);
-//
-//        java.io.InputStream data = con.getInputStream();
-//        byte[] dataBytes = new byte[32768];
-//        int readLen = data.read(dataBytes);
-//        int total = 0;
-//        while (readLen != -1) {
-//            total += readLen;
-//            sb.append(new String(dataBytes, 0, readLen));
-//            readLen = data.read(dataBytes);
-//        }
-//
-//        LOG.info(total + " bytes read for the resposne.");
-//        if (total != ExpectdResponseSize) {
-//            LOG.info("Response data : " + sb.toString());
-//        }
-//
-//        con.disconnect();
-//        LOG.info("Actual response size : " + sb.toString().length());
-//        //LOG.info("Contents of sb is " + sb.toString());
-//        //assertEquals(PostDataSize, sb.toString().length());
-//
-//        return total;
-//
-//    }
-    private int connectSendExpectDataSizeInResponse(int expectedResponseSize, String testToCall) throws Exception {
-        String urlString;
-        if (testToCall.equals("TestWriteFromFilter_AftersetWL")) {
-            urlString = "http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + WRITE_LISTENER__FILTER_SERVLET_URL;
-        } else {
-            urlString = "http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + WRITE_LISTENER_SERVLET_URL;
-        }
+    private int connectSendExpectDataSizeInResponse(int ExpectdResponseSize, String testtocall) throws Exception {
 
-        URL url = new URL(urlString);
-        HttpURLConnection con = (HttpURLConnection) url.openConnection();
+        String URLString = null;
+        if (testtocall.equals("TestWriteFromFilter_AftersetWL")) {
+            URLString = "http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + WRITE_LISTENER__FILTER_SERVLET_URL;
+        } else
+            URLString = "http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + WRITE_LISTENER_SERVLET_URL;
+
+        URL url = null;
+        HttpURLConnection con = null;
+        StringBuilder sb = new StringBuilder();
+
+        LOG.info("\n Request URL : " + URLString);
+
+        //char[] buffer = new char[1000];
+
+        url = new URL(URLString);
+        con = (HttpURLConnection) url.openConnection();
         con.setRequestMethod("POST");
-        con.setRequestProperty("TestToCall", testToCall);
-        con.setRequestProperty("ContentSizeSent", Integer.toString(expectedResponseSize));
+        con.setRequestProperty("TestToCall", testtocall);
+        con.setRequestProperty("ContentSizeSent", Integer.toString(ExpectdResponseSize));
         con.setDoOutput(true);
         con.setDoInput(true);
+        con.connect();
 
-        LOG.info("\nRequest URL: " + urlString);
+        LOG.info("Start reading the response.  Expected response size : " + ExpectdResponseSize);
 
-        try {
-            LOG.info("Start reading the response. Expected response size: " + expectedResponseSize);
-
-            int responseCode = con.getResponseCode();
-            LOG.info("HTTP Response Code: " + responseCode);
-            if (responseCode != HttpURLConnection.HTTP_OK) {
-                LOG.info("HTTP Response Code: " + responseCode);
-                return 0; // Handle the error as needed
-            }
-
-            int total = 0;
-            StringBuilder sb = new StringBuilder();
-            byte[] dataBytes = new byte[8192];
-            int readLen;
-
-            try (InputStream data = con.getInputStream()) {
-                while ((readLen = data.read(dataBytes)) != -1) {
-                    total += readLen;
-                    sb.append(new String(dataBytes, 0, readLen));
-                }
-            }
-
-            LOG.info(total + " bytes read for the response.");
-            if (total != expectedResponseSize) {
-                LOG.info("Response data: " + sb.toString());
-            }
-
-            LOG.info("Actual response size: " + sb.length());
-
-            return total;
-        } catch (IOException e) {
-            LOG.info("Error reading response: " + e.getMessage());
-
-            StringWriter sw = new StringWriter();
-            PrintWriter pw = new PrintWriter(sw);
-            e.printStackTrace(pw);
-            LOG.info("Stack:\n" + sw.toString());
-
-            e.printStackTrace();
-            return 0; // Handle the error as needed
-        } finally {
-            con.disconnect();
+        java.io.InputStream data = con.getInputStream();
+        byte[] dataBytes = new byte[32768];
+        int readLen = data.read(dataBytes);
+        int total = 0;
+        while (readLen != -1) {
+            total += readLen;
+            sb.append(new String(dataBytes, 0, readLen));
+            readLen = data.read(dataBytes);
         }
+
+        LOG.info(total + " bytes read for the resposne.");
+        if (total != ExpectdResponseSize) {
+            LOG.info("Response data : " + sb.toString());
+        }
+
+        con.disconnect();
+        LOG.info("Actual response size : " + sb.toString().length());
+        //LOG.info("Contents of sb is " + sb.toString());
+        //assertEquals(PostDataSize, sb.toString().length());
+
+        return total;
+
     }
+//    private int connectSendExpectDataSizeInResponse(int expectedResponseSize, String testToCall) throws Exception {
+//        String urlString;
+//        if (testToCall.equals("TestWriteFromFilter_AftersetWL")) {
+//            urlString = "http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + WRITE_LISTENER__FILTER_SERVLET_URL;
+//        } else {
+//            urlString = "http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + WRITE_LISTENER_SERVLET_URL;
+//        }
+//
+//        URL url = new URL(urlString);
+//        HttpURLConnection con = (HttpURLConnection) url.openConnection();
+//        con.setRequestMethod("POST");
+//        con.setRequestProperty("TestToCall", testToCall);
+//        con.setRequestProperty("ContentSizeSent", Integer.toString(expectedResponseSize));
+//        con.setDoOutput(true);
+//        con.setDoInput(true);
+//
+//        LOG.info("\nRequest URL: " + urlString);
+//
+//        try {
+//            LOG.info("Start reading the response. Expected response size: " + expectedResponseSize);
+//
+//            int responseCode = con.getResponseCode();
+//            LOG.info("HTTP Response Code: " + responseCode);
+//            if (responseCode != HttpURLConnection.HTTP_OK) {
+//                LOG.info("HTTP Response Code: " + responseCode);
+//                return 0; // Handle the error as needed
+//            }
+//
+//            int total = 0;
+//            StringBuilder sb = new StringBuilder();
+//            byte[] dataBytes = new byte[8192];
+//            int readLen;
+//
+//            try (InputStream data = con.getInputStream()) {
+//                while ((readLen = data.read(dataBytes)) != -1) {
+//                    total += readLen;
+//                    sb.append(new String(dataBytes, 0, readLen));
+//                }
+//            }
+//
+//            LOG.info(total + " bytes read for the response.");
+//            if (total != expectedResponseSize) {
+//                LOG.info("Response data: " + sb.toString());
+//            }
+//
+//            LOG.info("Actual response size: " + sb.length());
+//
+//            return total;
+//        } catch (IOException e) {
+//            LOG.info("Error reading response: " + e.getMessage());
+//
+//            StringWriter sw = new StringWriter();
+//            PrintWriter pw = new PrintWriter(sw);
+//            e.printStackTrace(pw);
+//            LOG.info("Stack:\n" + sw.toString());
+//
+//            e.printStackTrace();
+//            return 0; // Handle the error as needed
+//        } finally {
+//            con.disconnect();
+//        }
+//    }
 
     /**
      * @param ExpectdResponseSize

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/AsyncWriteListenerHttpUnit.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/AsyncWriteListenerHttpUnit.java
@@ -18,6 +18,8 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Objects;
@@ -621,55 +623,117 @@ public class AsyncWriteListenerHttpUnit {
      *
      *                       This method will not take care of println
      */
-    private int connectSendExpectDataSizeInResponse(int ExpectdResponseSize, String testtocall) throws Exception {
+//    private int connectSendExpectDataSizeInResponse(int ExpectdResponseSize, String testtocall) throws Exception {
+//
+//        String URLString = null;
+//        if (testtocall.equals("TestWriteFromFilter_AftersetWL")) {
+//            URLString = "http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + WRITE_LISTENER__FILTER_SERVLET_URL;
+//        } else
+//            URLString = "http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + WRITE_LISTENER_SERVLET_URL;
+//
+//        URL url = null;
+//        HttpURLConnection con = null;
+//        StringBuilder sb = new StringBuilder();
+//
+//        LOG.info("\n Request URL : " + URLString);
+//
+//        //char[] buffer = new char[1000];
+//
+//        url = new URL(URLString);
+//        con = (HttpURLConnection) url.openConnection();
+//        con.setRequestMethod("POST");
+//        con.setRequestProperty("TestToCall", testtocall);
+//        con.setRequestProperty("ContentSizeSent", Integer.toString(ExpectdResponseSize));
+//        con.setDoOutput(true);
+//        con.setDoInput(true);
+//        con.connect();
+//
+//        LOG.info("Start reading the response.  Expected response size : " + ExpectdResponseSize);
+//
+//        java.io.InputStream data = con.getInputStream();
+//        byte[] dataBytes = new byte[32768];
+//        int readLen = data.read(dataBytes);
+//        int total = 0;
+//        while (readLen != -1) {
+//            total += readLen;
+//            sb.append(new String(dataBytes, 0, readLen));
+//            readLen = data.read(dataBytes);
+//        }
+//
+//        LOG.info(total + " bytes read for the resposne.");
+//        if (total != ExpectdResponseSize) {
+//            LOG.info("Response data : " + sb.toString());
+//        }
+//
+//        con.disconnect();
+//        LOG.info("Actual response size : " + sb.toString().length());
+//        //LOG.info("Contents of sb is " + sb.toString());
+//        //assertEquals(PostDataSize, sb.toString().length());
+//
+//        return total;
+//
+//    }
+    private int connectSendExpectDataSizeInResponse(int expectedResponseSize, String testToCall) throws Exception {
+        String urlString;
+        if (testToCall.equals("TestWriteFromFilter_AftersetWL")) {
+            urlString = "http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + WRITE_LISTENER__FILTER_SERVLET_URL;
+        } else {
+            urlString = "http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + WRITE_LISTENER_SERVLET_URL;
+        }
 
-        String URLString = null;
-        if (testtocall.equals("TestWriteFromFilter_AftersetWL")) {
-            URLString = "http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + WRITE_LISTENER__FILTER_SERVLET_URL;
-        } else
-            URLString = "http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + WRITE_LISTENER_SERVLET_URL;
-
-        URL url = null;
-        HttpURLConnection con = null;
-        StringBuilder sb = new StringBuilder();
-
-        LOG.info("\n Request URL : " + URLString);
-
-        //char[] buffer = new char[1000];
-
-        url = new URL(URLString);
-        con = (HttpURLConnection) url.openConnection();
+        URL url = new URL(urlString);
+        HttpURLConnection con = (HttpURLConnection) url.openConnection();
         con.setRequestMethod("POST");
-        con.setRequestProperty("TestToCall", testtocall);
-        con.setRequestProperty("ContentSizeSent", Integer.toString(ExpectdResponseSize));
+        con.setRequestProperty("TestToCall", testToCall);
+        con.setRequestProperty("ContentSizeSent", Integer.toString(expectedResponseSize));
         con.setDoOutput(true);
         con.setDoInput(true);
-        con.connect();
 
-        LOG.info("Start reading the response.  Expected response size : " + ExpectdResponseSize);
+        LOG.info("\nRequest URL: " + urlString);
 
-        java.io.InputStream data = con.getInputStream();
-        byte[] dataBytes = new byte[32768];
-        int readLen = data.read(dataBytes);
-        int total = 0;
-        while (readLen != -1) {
-            total += readLen;
-            sb.append(new String(dataBytes, 0, readLen));
-            readLen = data.read(dataBytes);
+        try {
+            LOG.info("Start reading the response. Expected response size: " + expectedResponseSize);
+
+            int responseCode = con.getResponseCode();
+            LOG.info("HTTP Response Code: " + responseCode);
+            if (responseCode != HttpURLConnection.HTTP_OK) {
+                LOG.info("HTTP Response Code: " + responseCode);
+                return 0; // Handle the error as needed
+            }
+
+            int total = 0;
+            StringBuilder sb = new StringBuilder();
+            byte[] dataBytes = new byte[8192];
+            int readLen;
+
+            try (InputStream data = con.getInputStream()) {
+                while ((readLen = data.read(dataBytes)) != -1) {
+                    total += readLen;
+                    sb.append(new String(dataBytes, 0, readLen));
+                }
+            }
+
+            LOG.info(total + " bytes read for the response.");
+            if (total != expectedResponseSize) {
+                LOG.info("Response data: " + sb.toString());
+            }
+
+            LOG.info("Actual response size: " + sb.length());
+
+            return total;
+        } catch (IOException e) {
+            LOG.info("Error reading response: " + e.getMessage());
+
+            StringWriter sw = new StringWriter();
+            PrintWriter pw = new PrintWriter(sw);
+            e.printStackTrace(pw);
+            LOG.info("Stack:\n" + sw.toString());
+
+            e.printStackTrace();
+            return 0; // Handle the error as needed
+        } finally {
+            con.disconnect();
         }
-
-        LOG.info(total + " bytes read for the resposne.");
-        if (total != ExpectdResponseSize) {
-            LOG.info("Response data : " + sb.toString());
-        }
-
-        con.disconnect();
-        LOG.info("Actual response size : " + sb.toString().length());
-        //LOG.info("Contents of sb is " + sb.toString());
-        //assertEquals(PostDataSize, sb.toString().length());
-
-        return total;
-
     }
 
     /**
@@ -780,7 +844,12 @@ public class AsyncWriteListenerHttpUnit {
                 //Read and discard the response data while couting bytes
                 while ((bytesReadThisChunk = inputStream.read(buffer)) != -1) {
                     LOG.info("Reading chunk: " + bytesReadThisChunk);
-                    bytesRead += bytesReadThisChunk;
+                    for (int i = 0; i < bytesReadThisChunk; i++) {
+                        byte currentByte = buffer[i];
+                        if (currentByte != '\r' && currentByte != '\n') {
+                            bytesRead++;
+                        }
+                    }
                 }
 
                 // Compare total bytes read with expected size


### PR DESCRIPTION
Compatibility for Web Container's read / write async listeners. 

TODO: check `SRVE8055E*` , check if writing an H2 stream and use the StreamSpecificHttpContent in that case.

Added an implementation class to convert WsByteBuffers into Netty's ChukedInput to leverage use of Netty's `ChunkedWriteHandler `. Updated the syncWriteListenerHttpUnit. 