### PR TITLE
Netty socket pipeline allow half open

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpServiceContextImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpServiceContextImpl.java
@@ -3403,7 +3403,9 @@ public abstract class HttpServiceContextImpl implements HttpServiceContext, FFDC
             public void operationComplete(ChannelFuture arg0) throws Exception {
 
                 if (nettyContext.pipeline().get(LibertyHttpRequestHandler.class) == null) {
-                    System.out.println("Could not verify pipelined request because of null handler! Is this HTTP2?");
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(this, tc, "Could not verify pipelined request because of null handler on channel: " + nettyContext.channel() + " Is this HTTP2?");
+                    }
                 } else {
                     nettyContext.pipeline().get(LibertyHttpRequestHandler.class).processNextRequest();
                 }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/NettyChain.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/NettyChain.java
@@ -33,6 +33,7 @@ import com.ibm.wsspi.kernel.service.utils.FrameworkState;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelOption;
 import io.openliberty.netty.internal.ConfigConstants;
 import io.openliberty.netty.internal.NettyFramework;
 import io.openliberty.netty.internal.ServerBootstrapExtended;
@@ -229,6 +230,7 @@ public synchronized void stop() {
                                 .with(ConfigElement.SAMESITE,owner.getSamesiteConfig())
                                 .build();
 
+                bootstrap.childOption(ChannelOption.ALLOW_HALF_CLOSURE, true);
                 bootstrap.childHandler(httpPipeline);
 
                 serverChannel = nettyFramework.start(bootstrap, info.getHost(), info.getPort(), this::channelFutureHandler);

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/NettyHttpConstants.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/NettyHttpConstants.java
@@ -31,5 +31,6 @@ public class NettyHttpConstants {
     public static final AttributeKey<Boolean> IS_OUTBOUND_KEY = AttributeKey.valueOf("isOutbound");
     public static final AttributeKey<String> PROTOCOL = AttributeKey.valueOf("protocol");
     public static final AttributeKey<String> ENDPOINT_PID = AttributeKey.valueOf("endpointPID");
+    public static final AttributeKey<Boolean> HANDLING_REQUEST = AttributeKey.valueOf("handlingRequest");
 
 }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/inbound/HttpDispatcherHandler.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/inbound/HttpDispatcherHandler.java
@@ -23,7 +23,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http2.Http2Connection;
-import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2Exception.StreamException;
 import io.netty.handler.codec.http2.HttpConversionUtil;
 import io.netty.handler.codec.http2.HttpToHttp2ConnectionHandler;
@@ -39,9 +38,7 @@ public class HttpDispatcherHandler extends SimpleChannelInboundHandler<FullHttpR
     // private HttpDispatcherLink link;
 
     public HttpDispatcherHandler(HttpChannelConfig config) {
-
         super(false);
-
         Objects.requireNonNull(config);
         this.config = config;
     }
@@ -53,6 +50,7 @@ public class HttpDispatcherHandler extends SimpleChannelInboundHandler<FullHttpR
     }
 
     // Method to allow direct invocation
+    // TODO check if this can be cleaned up and removed
     public void processMessageDirectly(FullHttpRequest request) throws Exception {
         channelRead0(context, request);
     }
@@ -98,9 +96,9 @@ public class HttpDispatcherHandler extends SimpleChannelInboundHandler<FullHttpR
     @Override
     public void exceptionCaught(ChannelHandlerContext context, Throwable cause) throws Exception {
         MSP.log("Exception caught in channel. Channel: {}, Reason: {} " + context.channel() + " " + cause.getMessage() + " " + cause);
-        if (cause instanceof Http2Exception.StreamException) {
+        if (cause instanceof StreamException) {
             System.out.println("Got a HTTP2 stream exception!! Need to close the stream");
-            StreamException c = (Http2Exception.StreamException) cause;
+            StreamException c = (StreamException) cause;
             HttpToHttp2ConnectionHandler handler = context.pipeline().get(HttpToHttp2ConnectionHandler.class);
             Http2Connection connection = handler.connection();
             connection.stream(c.streamId()).close();

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/inbound/LibertyHttpRequestHandler.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/inbound/LibertyHttpRequestHandler.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.http.netty.pipeline.inbound;
+
+import java.util.concurrent.LinkedBlockingQueue;
+
+import com.ibm.ws.http.netty.NettyHttpConstants;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.socket.ChannelInputShutdownEvent;
+import io.netty.handler.codec.http.FullHttpRequest;
+
+/**
+ *
+ */
+public class LibertyHttpRequestHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
+
+    private final LinkedBlockingQueue<FullHttpRequest> requestQueue = new LinkedBlockingQueue<FullHttpRequest>();
+    private boolean peerClosedConnection = false;
+    private ChannelHandlerContext requestHandlerContext;
+
+    public LibertyHttpRequestHandler() {
+        super(false);
+        System.out.println("Added Request Handler!!");
+    }
+
+    @Override
+    public void handlerAdded(ChannelHandlerContext ctx) {
+        ctx.channel().attr(NettyHttpConstants.HANDLING_REQUEST).set(false);
+        System.out.println("Setting context: " + ctx);
+        requestHandlerContext = ctx;
+    }
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext context, FullHttpRequest request) throws Exception {
+        // TODO Need to see if we need to check decoder result from request to ensure data is properly parsed as expected
+        System.out.println("Reading Full HTTP Request for channel: " + context.channel());
+        if (request.decoderResult().isFinished() && request.decoderResult().isSuccess()) {
+            System.out.println("Success handling request, verifying if it needs to be queued");
+//            FullHttpRequest msg = ReferenceCountUtil.retain(request, 1);
+            synchronized (context.channel().attr(NettyHttpConstants.HANDLING_REQUEST)) {
+                if (context.channel().attr(NettyHttpConstants.HANDLING_REQUEST).get()) {
+                    System.out.println("Request in progress, queueing next request");
+                    requestQueue.add(request);
+                    return;
+                }
+                context.channel().attr(NettyHttpConstants.HANDLING_REQUEST).set(true);
+            }
+            System.out.println("Firing channel read!!");
+            context.fireChannelRead(request);
+        } else {
+            System.out.println("Caught an unsuccesful decode while decoding result! " + request.decoderResult().cause() + " so will ignore message: " + request);
+            if (request.decoderResult().cause() != null)
+                request.decoderResult().cause().printStackTrace();
+        }
+    }
+
+    @Override
+    public void userEventTriggered(ChannelHandlerContext context, Object evt) throws Exception {
+        System.out.println("User event triggered now! " + evt);
+        synchronized (context.channel().attr(NettyHttpConstants.HANDLING_REQUEST)) {
+            if (evt instanceof ChannelInputShutdownEvent) {
+                // If handling request we just need to wait until it ends to handle the error
+                // else we should close the channel up now
+                if (context.channel().attr(NettyHttpConstants.HANDLING_REQUEST).get()) {
+                    System.out.println("Peer closed the connection while we were handling a request, ending the connection after finishing writing");
+                    peerClosedConnection = true;
+                } else {
+                    System.out.println("Peer closed the connection and there was no request being handled, closing the channel");
+                    context.close();
+                    return;
+                }
+            }
+        }
+        super.userEventTriggered(context, evt);
+    }
+
+    // Method to allow for handling the next request if any in the queue of requests
+    public void processNextRequest() throws Exception {
+        System.out.println("ProcessNextRequest called!!");
+        synchronized (requestHandlerContext.channel().attr(NettyHttpConstants.HANDLING_REQUEST)) {
+            if (peerClosedConnection) {
+                System.out.println("Closing after peer finished the connection and we finished writing");
+                requestHandlerContext.close();
+                return;
+            }
+            if (requestQueue.isEmpty()) {
+                System.out.println("No further requests to process!!");
+                requestHandlerContext.channel().attr(NettyHttpConstants.HANDLING_REQUEST).set(false);
+                return;
+            }
+            requestHandlerContext.channel().attr(NettyHttpConstants.HANDLING_REQUEST).set(true);
+        }
+        System.out.println("Processing next request in queue!!");
+        requestHandlerContext.fireChannelRead(requestQueue.remove());
+    }
+
+}

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/inbound/LibertyHttpRequestHandler.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/inbound/LibertyHttpRequestHandler.java
@@ -11,6 +11,8 @@ package com.ibm.ws.http.netty.pipeline.inbound;
 
 import java.util.concurrent.LinkedBlockingQueue;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.http.netty.NettyHttpConstants;
 
 import io.netty.channel.ChannelHandlerContext;
@@ -19,9 +21,14 @@ import io.netty.channel.socket.ChannelInputShutdownEvent;
 import io.netty.handler.codec.http.FullHttpRequest;
 
 /**
- *
+ * Handler that works on queueing requests as they come through the aggregator for proper HTTP pipelining support
+ * and also handles the behavior of closing a connection after we finish processing HTTP 1.1 requests if the remote
+ * peer already closed the connection. This handler MUST be added before the dispatcher handler to be able to
+ * appropriately handle requests
  */
 public class LibertyHttpRequestHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
+
+    private static final TraceComponent tc = Tr.register(LibertyHttpRequestHandler.class);
 
     private final LinkedBlockingQueue<FullHttpRequest> requestQueue = new LinkedBlockingQueue<FullHttpRequest>();
     private boolean peerClosedConnection = false;
@@ -29,35 +36,36 @@ public class LibertyHttpRequestHandler extends SimpleChannelInboundHandler<FullH
 
     public LibertyHttpRequestHandler() {
         super(false);
-        System.out.println("Added Request Handler!!");
     }
 
     @Override
     public void handlerAdded(ChannelHandlerContext ctx) {
         ctx.channel().attr(NettyHttpConstants.HANDLING_REQUEST).set(false);
-        System.out.println("Setting context: " + ctx);
         requestHandlerContext = ctx;
     }
 
     @Override
     protected void channelRead0(ChannelHandlerContext context, FullHttpRequest request) throws Exception {
         // TODO Need to see if we need to check decoder result from request to ensure data is properly parsed as expected
-        System.out.println("Reading Full HTTP Request for channel: " + context.channel());
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(this, tc, "Reading Full HTTP Request for channel: " + context.channel());
+        }
         if (request.decoderResult().isFinished() && request.decoderResult().isSuccess()) {
-            System.out.println("Success handling request, verifying if it needs to be queued");
-//            FullHttpRequest msg = ReferenceCountUtil.retain(request, 1);
             synchronized (context.channel().attr(NettyHttpConstants.HANDLING_REQUEST)) {
                 if (context.channel().attr(NettyHttpConstants.HANDLING_REQUEST).get()) {
-                    System.out.println("Request in progress, queueing next request");
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(this, tc, "Request already in progress! Adding to request queue...");
+                    }
                     requestQueue.add(request);
                     return;
                 }
                 context.channel().attr(NettyHttpConstants.HANDLING_REQUEST).set(true);
             }
-            System.out.println("Firing channel read!!");
             context.fireChannelRead(request);
         } else {
-            System.out.println("Caught an unsuccesful decode while decoding result! " + request.decoderResult().cause() + " so will ignore message: " + request);
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(this, tc, "Caught an unsuccesful decode while decoding result! " + request.decoderResult().cause() + " so will ignore message: " + request);
+            }
             if (request.decoderResult().cause() != null)
                 request.decoderResult().cause().printStackTrace();
         }
@@ -65,16 +73,19 @@ public class LibertyHttpRequestHandler extends SimpleChannelInboundHandler<FullH
 
     @Override
     public void userEventTriggered(ChannelHandlerContext context, Object evt) throws Exception {
-        System.out.println("User event triggered now! " + evt);
-        synchronized (context.channel().attr(NettyHttpConstants.HANDLING_REQUEST)) {
-            if (evt instanceof ChannelInputShutdownEvent) {
-                // If handling request we just need to wait until it ends to handle the error
+        if (evt instanceof ChannelInputShutdownEvent) {
+            synchronized (context.channel().attr(NettyHttpConstants.HANDLING_REQUEST)) {
+                // If handling request we just need to wait until processing finishes to handle the closing
                 // else we should close the channel up now
                 if (context.channel().attr(NettyHttpConstants.HANDLING_REQUEST).get()) {
-                    System.out.println("Peer closed the connection while we were handling a request, ending the connection after finishing writing");
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(this, tc, "Peer closed the connection while we were handling a request, ending the connection after finishing processing");
+                    }
                     peerClosedConnection = true;
                 } else {
-                    System.out.println("Peer closed the connection and there was no request being handled, closing the channel");
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(this, tc, "Peer closed the connection and there was no request being handled, closing the channel");
+                    }
                     context.close();
                     return;
                 }
@@ -84,22 +95,27 @@ public class LibertyHttpRequestHandler extends SimpleChannelInboundHandler<FullH
     }
 
     // Method to allow for handling the next request if any in the queue of requests
-    public void processNextRequest() throws Exception {
-        System.out.println("ProcessNextRequest called!!");
+    public void processNextRequest() {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(this, tc, "Processing next available request in request queue");
+        }
         synchronized (requestHandlerContext.channel().attr(NettyHttpConstants.HANDLING_REQUEST)) {
             if (peerClosedConnection) {
-                System.out.println("Closing after peer finished the connection and we finished writing");
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(this, tc, "Closing connection: " + requestHandlerContext.channel() + " because peer ended the connection and we have finished processing.");
+                }
                 requestHandlerContext.close();
                 return;
             }
             if (requestQueue.isEmpty()) {
-                System.out.println("No further requests to process!!");
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(this, tc, "No additional requests found in queue...");
+                }
                 requestHandlerContext.channel().attr(NettyHttpConstants.HANDLING_REQUEST).set(false);
                 return;
             }
             requestHandlerContext.channel().attr(NettyHttpConstants.HANDLING_REQUEST).set(true);
         }
-        System.out.println("Processing next request in queue!!");
         requestHandlerContext.fireChannelRead(requestQueue.remove());
     }
 

--- a/dev/com.ibm.ws.transport.http2_fat/test-applications/H2FATDriver.war/src/http2/test/driver/war/servlets/DataFrameTests.java
+++ b/dev/com.ibm.ws.transport.http2_fat/test-applications/H2FATDriver.war/src/http2/test/driver/war/servlets/DataFrameTests.java
@@ -51,7 +51,7 @@ public class DataFrameTests extends H2FATDriverServlet {
         Http2Client h2Client = getDefaultH2Client(request, response, blockUntilConnectionIsDone);
 
         byte[] chfwDebugData = "DATA Frame Received in the wrong state of: IDLE".getBytes();
-        byte[] nettyDebugData = "Stream 3 does not exist".getBytes();
+        byte[] nettyDebugData = "Stream 3 does not exist for inbound frame DATA, endOfStream = false".getBytes();
         FrameGoAway errorFrame;
         if (USING_NETTY)
             errorFrame = new FrameGoAway(0, nettyDebugData, PROTOCOL_ERROR, 2147483647, false);

--- a/dev/com.ibm.ws.transport.http2_fat/test-applications/H2FATDriver.war/src/http2/test/driver/war/servlets/H2FATDriverServlet.java
+++ b/dev/com.ibm.ws.transport.http2_fat/test-applications/H2FATDriver.war/src/http2/test/driver/war/servlets/H2FATDriverServlet.java
@@ -2008,7 +2008,7 @@ public class H2FATDriverServlet extends FATServlet {
         Http2Client h2Client = getDefaultH2Client(request, response, blockUntilConnectionIsDone);
 
         byte[] chfwDebugData = "DATA Frame Received in the wrong state of: IDLE".getBytes();
-        byte[] nettyDebugData = "Stream 3 does not exist".getBytes();
+        byte[] nettyDebugData = "Stream 3 does not exist for inbound frame DATA, endOfStream = true".getBytes();
         FrameGoAway errorFrame;
         if (USING_NETTY)
             errorFrame = new FrameGoAway(0, nettyDebugData, PROTOCOL_ERROR, 2147483647, false);
@@ -2037,7 +2037,7 @@ public class H2FATDriverServlet extends FATServlet {
         Http2Client h2Client = getDefaultH2Client(request, response, blockUntilConnectionIsDone);
 
         byte[] chfwDebugData = "RST_STREAM Frame Received in the wrong state of: IDLE".getBytes();
-        byte[] nettyDebugData = "Stream 3 does not exist".getBytes();
+        byte[] nettyDebugData = "Stream 3 does not exist for inbound frame RST_STREAM, endOfStream = false".getBytes();
         FrameGoAway errorFrame;
         if (USING_NETTY)
             errorFrame = new FrameGoAway(0, nettyDebugData, PROTOCOL_ERROR, 2147483647, false);
@@ -2066,7 +2066,7 @@ public class H2FATDriverServlet extends FATServlet {
         Http2Client h2Client = getDefaultH2Client(request, response, blockUntilConnectionIsDone);
 
         byte[] chfwDebugData = "WINDOW_UPDATE Frame Received in the wrong state of: IDLE".getBytes();
-        byte[] nettyDebugData = "Stream 3 does not exist".getBytes();
+        byte[] nettyDebugData = "Stream 3 does not exist for inbound frame WINDOW_UPDATE, endOfStream = false".getBytes();
         FrameGoAway errorFrame;
         if (USING_NETTY)
             errorFrame = new FrameGoAway(0, nettyDebugData, PROTOCOL_ERROR, 2147483647, false);

--- a/dev/com.ibm.ws.transport.http2_fat/test-applications/H2FATDriver.war/src/http2/test/driver/war/servlets/PushPromiseTests.java
+++ b/dev/com.ibm.ws.transport.http2_fat/test-applications/H2FATDriver.war/src/http2/test/driver/war/servlets/PushPromiseTests.java
@@ -124,7 +124,7 @@ public class PushPromiseTests extends H2FATDriverServlet {
                     secondHeadersReceived.add(new H2HeaderField("x-powered-by", "Servlet/4.0"));
                     secondHeadersReceived.add(new H2HeaderField("date", ".*")); //regex because date will vary
                     FrameHeadersClient secondFrameHeaders;
-                    secondFrameHeaders = new FrameHeadersClient(promisedStreamId, null, 0, 0, 15, true, true, false, true, false, false);
+                    secondFrameHeaders = new FrameHeadersClient(promisedStreamId, null, 0, 0, 15, false, true, false, true, false, false);
                     secondFrameHeaders.setHeaderFields(secondHeadersReceived);
                     try {
                         h2Client.addExpectedFrame(secondFrameHeaders);
@@ -140,7 +140,7 @@ public class PushPromiseTests extends H2FATDriverServlet {
                     thirdHeadersReceived.add(new H2HeaderField(":status", "200"));
                     thirdHeadersReceived.add(new H2HeaderField("x-powered-by", "Servlet/4.0"));
                     thirdHeadersReceived.add(new H2HeaderField("date", ".*")); //regex because date will vary
-                    FrameHeadersClient thirdFrameHeaders = new FrameHeadersClient(promisedStreamId, null, 0, 0, 15, true, true, false, true, false, false);
+                    FrameHeadersClient thirdFrameHeaders = new FrameHeadersClient(promisedStreamId, null, 0, 0, 15, false, true, false, true, false, false);
                     thirdFrameHeaders.setHeaderFields(thirdHeadersReceived);
                     try {
                         h2Client.addExpectedFrame(thirdFrameHeaders);


### PR DESCRIPTION
- Added logic for HTTP 1.1 pipelining
- Added option to allow half open sockets
- Added logic to match behavior in legacy for H1 and H2 writes
- Fixed issues with H2 after rebase