### PR TITLE
Added changes to use the correct ssl alias and properties for Netty

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/NettyChain.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/NettyChain.java
@@ -21,7 +21,6 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.http.channel.internal.HttpConfigConstants;
 import com.ibm.ws.http.channel.internal.HttpMessages;
 import com.ibm.ws.http.internal.HttpChain;
-import com.ibm.ws.http.internal.HttpChain.ActiveConfiguration;
 import com.ibm.ws.http.internal.HttpChain.ChainState;
 import com.ibm.ws.http.internal.HttpEndpointImpl;
 import com.ibm.ws.http.internal.HttpServiceConstants;
@@ -98,7 +97,7 @@ public class NettyChain extends HttpChain {
             Tr.entry(this, tc, "Stopping Netty Chain: " + endpointName + ", Current state: " + state.get());
         }
 
-        if (state.get() == ChainState.STARTED) {
+        if (state.get() == ChainState.STARTED || state.get() == ChainState.STARTING) {
             endpointMgr.removeEndPoint(endpointName);
             state.set(ChainState.STOPPING);
 

--- a/dev/io.openliberty.netty.internal.tls.impl/bnd.bnd
+++ b/dev/io.openliberty.netty.internal.tls.impl/bnd.bnd
@@ -26,6 +26,7 @@ Export-Package: io.openliberty.netty.internal.tls.impl
 
 Import-Package: \
   io.openliberty.netty.internal.tls,\
+  io.openliberty.netty.internal.exception,\
   ${defaultPackageImport}
 
 -dsannotations: \


### PR DESCRIPTION
For addressing issues with springboot FATs related to SSL, there were missing ciphers and ssl options that were not properly picked up by the current SSL implementation which needed to be added.