### PR TITLE
Update endpoint closing for Netty bundle

### DIFF
--- a/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/impl/NettyFrameworkImpl.java
+++ b/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/impl/NettyFrameworkImpl.java
@@ -494,6 +494,7 @@ public class NettyFrameworkImpl implements ServerQuiesceListener, NettyFramework
     @Override
     public ChannelFuture stop(Channel channel) {
     	synchronized (activeChannelMap) {
+    		ChannelFuture closeFuture = channel.close();
 	    	ChannelGroup group = activeChannelMap.get(channel);
 	    	if(group != null) {
 	    		group.close().addListener(innerFuture -> {
@@ -503,7 +504,7 @@ public class NettyFrameworkImpl implements ServerQuiesceListener, NettyFramework
 	    		});
 	    		activeChannelMap.remove(channel);
 	    	}
-	    	return channel.close();
+	    	return closeFuture;
     	}
     }
 


### PR DESCRIPTION
Updated when an HTTP endpoint closes when a close is called for handling issues with jca tests
