### PR TITLE
Handle UnresolvedAddressException During Pipeline Startup

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/NettyChain.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/NettyChain.java
@@ -254,11 +254,7 @@ public class NettyChain extends HttpChain {
     }
 
     private void channelFutureHandler(ChannelFuture future) {
-        //TODO: check this synchronization behaves as intended
         synchronized (this) {
-
-
-
             if (future.isSuccess()) {
                 state.set(ChainState.STARTED);
                 EndPointInfo info = endpointMgr.getEndPoint(this.endpointName);
@@ -266,30 +262,10 @@ public class NettyChain extends HttpChain {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                     Tr.debug(this, tc, "Channel is now active and listening on port " + getActivePort());
                 }
-
             } else {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                     Tr.debug(this, tc, "Channel failed to bind to port:  " + future.cause());
                 }
-
-                // // Check if the exception is or was caused by UnresolvedAddressException
-                // Throwable cause = future.cause();
-                // boolean unresolvedAddress = false;
-
-                // while (cause != null) {
-                //     if (cause instanceof java.nio.channels.UnresolvedAddressException) {
-                //         unresolvedAddress = true;
-                //         break;
-                //     }
-                //     cause = cause.getCause();
-                // }
-
-                // if (unresolvedAddress) {
-                //     // Log the specific error message
-                //     Tr.error(tc, TCPChannelMessageConstants.LOCAL_HOST_UNRESOLVED,
-                //         new Object[] {this.endpointName, currentConfig.configHost, currentConfig.configPort});
-                // }
-
                 handleStartupError(new NettyException(future.cause()), currentConfig);
                 
                 if (currentConfig != null) {
@@ -403,5 +379,4 @@ public class NettyChain extends HttpChain {
                + ",config=" + currentConfig + "]";
 
     }
-
 }


### PR DESCRIPTION

- [x] Considered risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes)
- [x] Resolved Issues: Fixes #FILLMEIN... (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions)
- [x] Resolved external Known Issues (including APARS): Fixes #FILLMEIN...

This PR add support for handling `UnresolvedAddressException` instances during the TCP `open` method when starting up the Netty pipeline. 

- When the retry attempt threshold is met, the code will now verify the failure cause and if it is an `UnresolvedAddressException` it will log the appropriate Tr.error for message `CWWKO0224E`
- Relevant Tests ->  test.server.transport.http.HttpChainsTest
- [x] `testBadHostName`
- [x] `testGoodBadHostName`