### PR TITLE
Accept netty http2 exception direct upgrade

### DIFF
--- a/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2Config31H2Off.java
+++ b/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2Config31H2Off.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
+import componenttest.annotation.AllowedFFDC;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -127,6 +128,7 @@ public class Http2Config31H2Off extends FATServletClient {
      * @throws Exception
      */
     @Test
+    @AllowedFFDC("java.lang.IllegalArgumentException")
     public void servlet31H2OffDirectConnection() throws Exception {
         runTest(Http2FullModeTests.defaultServletPath, testName.getMethodName());
     }


### PR DESCRIPTION
There are exceptions that come directly from the Netty codec that get wrapped up as FFDCs. One of these show up on the direct upgrade to H2 test. We should have more discussion about how extra FFDCs could show up from the Netty codec and how we should handle them. In the meantime, we are allowing this FFDC based off discussions in the team.