### PR TITLE
Security commons improvement for authorization header

### DIFF
--- a/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/http/AuthUtils.java
+++ b/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/http/AuthUtils.java
@@ -50,8 +50,24 @@ public class AuthUtils {
             return rawHeaderValue;
         }
         if (scheme != null) {
-            if (rawHeaderValue.startsWith(scheme)) {
-                return rawHeaderValue.substring(scheme.length()).trim();
+            String schemeTrimmed = scheme.trim(); // Remove any trailing spaces from the scheme
+            int schemeLength = schemeTrimmed.length();
+
+            if (rawHeaderValue.equalsIgnoreCase(schemeTrimmed)) {
+                // No token is present
+                return "";
+            }
+
+            if (rawHeaderValue.length() > schemeLength &&
+                rawHeaderValue.regionMatches(true, 0, schemeTrimmed, 0, schemeLength)) {
+
+                // Check if the character after the scheme is whitespace
+                char charAfterScheme = rawHeaderValue.charAt(schemeLength);
+                if (Character.isWhitespace(charAfterScheme)) {
+                    // Extract the token after the whitespace
+                    String token = rawHeaderValue.substring(schemeLength + 1).trim();
+                    return token;
+                }
             }
         }
         return rawHeaderValue;

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyBaseMessage.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyBaseMessage.java
@@ -217,7 +217,16 @@ public class NettyBaseMessage implements HttpBaseMessage, Externalizable {
 
     @Override
     public HeaderField getHeader(String name) {
-        return new NettyHeader(name, headers);
+        Objects.requireNonNull(name, "Header name cannot be null");
+        String value = headers.get(name);
+        if(value != null){
+            if (value.isEmpty()) { 
+                value = null;
+            }
+
+            return new NettyHeader(name, value);
+        }
+        return NettyHeader.NULL_HEADER;
     }
 
     @Override
@@ -227,7 +236,7 @@ public class NettyBaseMessage implements HttpBaseMessage, Externalizable {
 
     @Override
     public HeaderField getHeader(HeaderKeys name) {
-        return new NettyHeader(name, headers);
+        return getHeader(name.getName());
     }
 
     @Override

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyHeader.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyHeader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@
 package com.ibm.ws.http.netty.message;
 
 import java.text.ParseException;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
@@ -22,7 +23,7 @@ import com.ibm.wsspi.http.channel.values.HttpHeaderKeys;
 import io.netty.handler.codec.http.HttpHeaders;
 
 /**
- * Wrapper for HeaderField compatibility within the transport
+ * Wrapper for HeaderField compatibility within the Netty transport layer.
  */
 public class NettyHeader implements HeaderField {
 
@@ -30,6 +31,7 @@ public class NettyHeader implements HeaderField {
     String name;
     String value;
     HeaderKeys key;
+    public static final HeaderField NULL_HEADER = new EmptyHeaderField();
 
     public NettyHeader(String name, HttpHeaders nettyHeaders) {
 
@@ -38,6 +40,7 @@ public class NettyHeader implements HeaderField {
 
         Objects.nonNull(nettyHeaders);
         this.nettyHeaders = nettyHeaders;
+        this.value = nettyHeaders.get(name);
 
         this.key = HttpHeaderKeys.find(name, Boolean.TRUE);
     }
@@ -49,6 +52,7 @@ public class NettyHeader implements HeaderField {
 
         Objects.nonNull(headers);
         this.nettyHeaders = headers;
+        this.value = headers.get(name);
 
     }
 
@@ -56,7 +60,7 @@ public class NettyHeader implements HeaderField {
         Objects.nonNull(name);
         this.name = name;
 
-        this.value = Objects.isNull(value) ? "" : value;
+        this.value = value;
         this.key = HttpHeaderKeys.find(name, Boolean.TRUE);
     }
 
@@ -73,7 +77,7 @@ public class NettyHeader implements HeaderField {
     @Override
     public String asString() {
 
-        return (Objects.nonNull(value)) ? this.value : nettyHeaders.get(name);
+        return (Objects.nonNull(value)&& !value.isEmpty()) ? this.value : null;
     }
 
     @Override
@@ -87,20 +91,53 @@ public class NettyHeader implements HeaderField {
 
     @Override
     public Date asDate() throws ParseException {
-
-        return HttpDispatcher.getDateFormatter().parseTime(asString());
-
+        if(value != null && !value.isEmpty()){
+            return HttpDispatcher.getDateFormatter().parseTime(asString());
+        }
+        return null;
     }
 
     @Override
     public int asInteger() throws NumberFormatException {
-        // TODO Auto-generated method stub
-        return nettyHeaders.getInt(name);
+        if (value != null && !value.isEmpty()){
+            return nettyHeaders.getInt(name);
+        }
+        return 0;
     }
 
     @Override
     public List<byte[]> asTokens(byte delimiter) {
         throw new UnsupportedOperationException("Unused in Netty Context");
+
+    }
+
+    private static class EmptyHeaderField implements HeaderField {
+
+        @Override
+        public String getName() { return null; }
+
+        @Override
+        public HeaderKeys getKey() { return null;}
+
+        @Override
+        public String asString() { return null; }
+
+        @Override
+        public byte[] asBytes() { return null; }
+
+        @Override
+        public Date asDate() throws ParseException { return null; }
+
+        @Override
+        public int asInteger() throws NumberFormatException { return 0; }
+
+        @Override
+        public List<byte[]> asTokens(byte delimiter){
+            return new ArrayList<>();
+        }
+
+        @Override
+        public String toString() { return "null header"; }
 
     }
 


### PR DESCRIPTION

- [ ] Considered risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes)
- [ ] Resolved Issues: Fixes #FILLMEIN... (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions)
- [ ] Resolved external Known Issues (including APARS): Fixes #FILLMEIN...

1.  **Adjusted Handling of Missing Headers ( NULL_HEADER implementation)**
- Implemented a `NULL_HEADER` that closely resembles the legacy implementation. 
2. **Adjustment of `getBearerTokenFromHeader`**
- In the Netty implementation the `Authorization` header value gets trimmed of trailing whitespaces during parsing. In legacy, the transport does not trim it (e.g., "Bearer "). Because of this difference, the security.common utility API fails to identify the token as empty. 
- The method now handles cases where the `Authorization` header value may not contain a whitespace. 
- Tested with `com.ibm.ws.security.social_fat.okdServiceLogin` (legacy and beta)
3. **NettyHeader improvements**
- Updated methods `asString()`, `asDate()`, and `asInteger()` to handle null and empty values appropriately. 

