### PR TITLE
Performance netty header date response validation updates

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpServiceContextImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpServiceContextImpl.java
@@ -3312,15 +3312,13 @@ public abstract class HttpServiceContextImpl implements HttpServiceContext, FFDC
         }
         setMessageSent();
         // Queue next read request for pipelining
-        HttpDispatcher.getExecutorService().submit(()->{
-            if (nettyContext.pipeline().get(LibertyHttpRequestHandler.class) == null) {
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(this, tc, "Could not verify pipelined request because of null handler on channel: " + nettyContext.channel() + " Is this HTTP2?");
-                }
-            } else {
-                nettyContext.pipeline().get(LibertyHttpRequestHandler.class).processNextRequest();
-            }        
-        });
+        if (nettyContext.pipeline().get(LibertyHttpRequestHandler.class) == null) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(this, tc, "Could not verify pipelined request because of null handler on channel: " + nettyContext.channel() + " Is this HTTP2?");
+            }
+        } else {
+            nettyContext.pipeline().get(LibertyHttpRequestHandler.class).processNextRequest();
+        }
     }
 
     /**

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpDispatcherLink.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpDispatcherLink.java
@@ -77,6 +77,7 @@ import com.ibm.wsspi.tcpchannel.TCPConnectionContext;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.DefaultHttpHeadersFactory;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -208,7 +209,7 @@ public class HttpDispatcherLink extends InboundApplicationLink implements HttpIn
         this.request = new HttpRequestImpl(HttpDispatcher.useEE7Streams());
 
         this.response = new HttpResponseImpl(this);
-        isc.setNettyResponse(new DefaultHttpResponse(nettyRequest.protocolVersion(), HttpResponseStatus.OK));
+        isc.setNettyResponse(new DefaultHttpResponse(nettyRequest.protocolVersion(), HttpResponseStatus.OK, DefaultHttpHeadersFactory.headersFactory().withValidation(false)));
         this.nettyConnectionLink = new NettyConnectionLink(context.channel());
         super.init(nettyVc);
     }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/inbound/NettyTCPWriteRequestContext.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/inbound/NettyTCPWriteRequestContext.java
@@ -14,6 +14,8 @@ import java.nio.ByteBuffer;
 import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.Queue;
+import java.util.LinkedList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -198,7 +200,7 @@ public class NettyTCPWriteRequestContext implements TCPWriteRequestContext {
 
     }
 
-    private void awaitChannelFuture(ChannelFuture future, String failureMsg)
+    private void awaitChannelFuture(ChannelPromise future, String failureMsg)
         throws IOException, InterruptedException {
         CountDownLatch latch = new CountDownLatch(1);
         future.addListener(f -> latch.countDown());
@@ -232,6 +234,11 @@ public class NettyTCPWriteRequestContext implements TCPWriteRequestContext {
         long writtenBytes = 0L;
         // If using HTTP2 chunk logic or something else, keep the relevant parts.
         final String protocol = nettyChannel.attr(NettyHttpConstants.PROTOCOL).get();
+
+        // A write queue to run all the write events inside the eventloop to improve performance
+        // TODO Maybe we should see if this writequeue should belong to the class to improve performance?
+        final Queue<Object> writeQueue = new LinkedList<Object>();
+        final ChannelPromise writePromise = nettyChannel.newPromise();
       
         final boolean isHttp10 = "HTTP10".equals(protocol);
         final boolean isWsoc = "WebSocket".equals(protocol);
@@ -248,25 +255,39 @@ public class NettyTCPWriteRequestContext implements TCPWriteRequestContext {
                     writtenBytes += buffer.remaining();
                     ByteBuf nettyBuf = Unpooled.wrappedBuffer(WsByteBufferUtils.asByteArray(buffer));
                     HttpContent httpContent = new StreamSpecificHttpContent(Integer.valueOf(this.streamID), Unpooled.wrappedBuffer(WsByteBufferUtils.asByteArray(buffer)));
-                    ChannelFuture future = nettyChannel.write(httpContent);
+                    // ChannelFuture future = nettyChannel.write(httpContent);
+                    writeQueue.add(httpContent);
                   
                 } else if (hasContentLength || isWsoc || isHttp10) {
                     ByteBuf nettyBuf = Unpooled.wrappedBuffer(WsByteBufferUtils.asByteArray(buffer));
                     int bytes = nettyBuf.readableBytes();
-                    ChannelFuture future = nettyChannel.write(nettyBuf);
+                    // ChannelFuture future = nettyChannel.write(nettyBuf);
+                    writeQueue.add(nettyBuf);
                     writtenBytes += bytes;
 
                 } else {
 
                     ByteBuf nettyBuf = Unpooled.wrappedBuffer(WsByteBufferUtils.asByteArray(buffer));
                     DefaultHttpContent httpContent = new DefaultHttpContent(nettyBuf);
-                    ChannelFuture future = nettyChannel.write(httpContent);
+                    // ChannelFuture future = nettyChannel.write(httpContent);
                     writtenBytes += nettyBuf.readableBytes();
+                    writeQueue.add(httpContent);
                 }
             }
 
-            ChannelFuture flushFuture = nettyChannel.writeAndFlush(Unpooled.EMPTY_BUFFER);
-            awaitChannelFuture(flushFuture, "Flush operation timed out!");
+            // ChannelFuture flushFuture = nettyChannel.writeAndFlush(Unpooled.EMPTY_BUFFER);
+            // Run all the operations in the event loop
+
+            nettyChannel.eventLoop().execute(new Runnable() {
+                @Override
+                public void run() {
+                    for(Object writeBuffer : writeQueue){
+                        nettyChannel.write(writeBuffer);
+                    }
+                    nettyChannel.writeAndFlush(Unpooled.EMPTY_BUFFER, writePromise);
+                }
+            });
+            awaitChannelFuture(writePromise, "Flush operation timed out!");
 
 
         } catch (InterruptedException e) {
@@ -284,8 +305,12 @@ public class NettyTCPWriteRequestContext implements TCPWriteRequestContext {
         verifyTimeout(timeout);
         boolean wasWritable = nettyChannel.isWritable();
         long totalWrittenBytes = 0;
-        ChannelFuture lastWriteFuture = null;
+        // ChannelFuture lastWriteFuture = null;
         boolean hasContentLength = nettyChannel.hasAttr(NettyHttpConstants.CONTENT_LENGTH) && Objects.nonNull(nettyChannel.attr(NettyHttpConstants.CONTENT_LENGTH).get());
+        // A write queue to run all the write events inside the eventloop to improve performance
+        // TODO Maybe we should see if this writequeue should belong to the class to improve performance?
+        final Queue<Object> writeQueue = new LinkedList<Object>();
+        final ChannelPromise writePromise = nettyChannel.newPromise();
         //check if wsoc
         final String protocol = nettyChannel.attr(NettyHttpConstants.PROTOCOL).get();
 
@@ -313,7 +338,8 @@ public class NettyTCPWriteRequestContext implements TCPWriteRequestContext {
                             totalWrittenBytes += buffer.remaining();
                             ByteBuf nettyBuf = Unpooled.wrappedBuffer(WsByteBufferUtils.asByteArray(buffer));
                             HttpContent httpContent = new StreamSpecificHttpContent(Integer.valueOf(this.streamID), Unpooled.wrappedBuffer(WsByteBufferUtils.asByteArray(buffer)));
-                            lastWriteFuture = this.nettyChannel.write(httpContent);
+                            // lastWriteFuture = this.nettyChannel.write(httpContent);
+                            writeQueue.add(httpContent);
 
                         }
                         else if (hasContentLength || isWsoc || isHttp10) {
@@ -321,8 +347,9 @@ public class NettyTCPWriteRequestContext implements TCPWriteRequestContext {
                                 Tr.debug(this, tc, "Writing async on channel: " + nettyChannel + " which is wsoc? " + isWsoc);
                             }
                             ByteBuf nettyBuf = Unpooled.wrappedBuffer(WsByteBufferUtils.asByteArray(buffer));
-                            lastWriteFuture = this.nettyChannel.write(nettyBuf); // Write data to the channel
+                            // lastWriteFuture = this.nettyChannel.write(nettyBuf); // Write data to the channel
                             totalWrittenBytes += nettyBuf.readableBytes();
+                            writeQueue.add(nettyBuf);
                         }
 
                         else {
@@ -333,8 +360,9 @@ public class NettyTCPWriteRequestContext implements TCPWriteRequestContext {
                             ByteBuf nettyBuf = Unpooled.wrappedBuffer(WsByteBufferUtils.asByteArray(buffer));
                             DefaultHttpContent httpContent = new DefaultHttpContent(nettyBuf);
 
-                            lastWriteFuture = nettyChannel.write(httpContent);
+                            // lastWriteFuture = nettyChannel.write(httpContent);
                             totalWrittenBytes += nettyBuf.readableBytes();
+                            writeQueue.add(httpContent);
                         }
 
 //                        ByteBuf nettyBuf = Unpooled.wrappedBuffer(WsByteBufferUtils.asByteArray(buffer));
@@ -344,7 +372,19 @@ public class NettyTCPWriteRequestContext implements TCPWriteRequestContext {
                 }
             }
 
-            lastWriteFuture = nettyChannel.writeAndFlush(Unpooled.EMPTY_BUFFER);
+            // lastWriteFuture = nettyChannel.writeAndFlush(Unpooled.EMPTY_BUFFER);
+
+            // Run all the operations in the event loop
+
+            nettyChannel.eventLoop().execute(new Runnable() {
+                @Override
+                public void run() {
+                    for(Object writeBuffer : writeQueue){
+                        nettyChannel.write(writeBuffer);
+                    }
+                    nettyChannel.writeAndFlush(Unpooled.EMPTY_BUFFER, writePromise);
+                }
+            });
 
             boolean stillWritable = nettyChannel.isWritable();
 
@@ -353,10 +393,10 @@ public class NettyTCPWriteRequestContext implements TCPWriteRequestContext {
                 return null;
             }
 
-            if (lastWriteFuture == null && wasWritable && stillWritable && totalWrittenBytes >= numBytes) {
+            if (writePromise == null && wasWritable && stillWritable && totalWrittenBytes >= numBytes) {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(this, tc, "Found lastWriteFuture to be null or unable to keep writing on channel: " + nettyChannel);
-                    Tr.debug(this, tc, "lastWriteFuture: " + lastWriteFuture + " wasWritable: " + wasWritable + " stillWritable: " + stillWritable + " totalWrittenBytes: "
+                    Tr.debug(this, tc, "Found writePromise to be null or unable to keep writing on channel: " + nettyChannel);
+                    Tr.debug(this, tc, "writePromise: " + writePromise + " wasWritable: " + wasWritable + " stillWritable: " + stillWritable + " totalWrittenBytes: "
                                        + totalWrittenBytes + " numBytes: " + numBytes);
                 }
                 // Every thing was written here. Do callback in another thread
@@ -379,11 +419,11 @@ public class NettyTCPWriteRequestContext implements TCPWriteRequestContext {
 
             } else {
 
-                if (lastWriteFuture != null) {
+                if (writePromise != null) {
                     // We don't have to do the callback if everything wrote properly
-                    if (lastWriteFuture.isDone()) {
+                    if (writePromise.isDone()) {
                         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                            Tr.debug(this, tc, "Found lastWriteFuture to be finished on channel: " + nettyChannel);
+                            Tr.debug(this, tc, "Found writePromise to be finished on channel: " + nettyChannel);
                         }
                         // Everything was written, if forceQueue need to do callback on another thread
                         if (forceQueue) {
@@ -401,9 +441,9 @@ public class NettyTCPWriteRequestContext implements TCPWriteRequestContext {
                         return vc;
                     }
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                        Tr.debug(this, tc, "Went async, found lastWriteFuture to be running on channel: " + nettyChannel);
+                        Tr.debug(this, tc, "Went async, found writePromise to be running on channel: " + nettyChannel);
                     }
-                    lastWriteFuture.addListener((ChannelFutureListener) future -> {
+                    writePromise.addListener((ChannelFutureListener) future -> {
                         boolean succeeded = future.isSuccess();
                         HttpDispatcher.getExecutorService().submit(() -> {
                             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
@@ -418,7 +458,7 @@ public class NettyTCPWriteRequestContext implements TCPWriteRequestContext {
                     });
                 } else {
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                        Tr.debug(this, tc, "In else block with lastWriteFuture being null for channel: " + nettyChannel);
+                        Tr.debug(this, tc, "In else block with writePromise being null for channel: " + nettyChannel);
                     }
                 }
             }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/inbound/NettyTCPWriteRequestContext.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/inbound/NettyTCPWriteRequestContext.java
@@ -236,7 +236,8 @@ public class NettyTCPWriteRequestContext implements TCPWriteRequestContext {
         final String protocol = nettyChannel.attr(NettyHttpConstants.PROTOCOL).get();
 
         // A write queue to run all the write events inside the eventloop to improve performance
-        // TODO Maybe we should see if this writequeue should belong to the class to improve performance?
+        // Maybe we should see if this writequeue should belong to the class to improve performance?
+        // See https://github.com/OpenLiberty/open-liberty/issues/31555
         final Queue<Object> writeQueue = new LinkedList<Object>();
         final ChannelPromise writePromise = nettyChannel.newPromise();
       
@@ -255,13 +256,11 @@ public class NettyTCPWriteRequestContext implements TCPWriteRequestContext {
                     writtenBytes += buffer.remaining();
                     ByteBuf nettyBuf = Unpooled.wrappedBuffer(WsByteBufferUtils.asByteArray(buffer));
                     HttpContent httpContent = new StreamSpecificHttpContent(Integer.valueOf(this.streamID), Unpooled.wrappedBuffer(WsByteBufferUtils.asByteArray(buffer)));
-                    // ChannelFuture future = nettyChannel.write(httpContent);
                     writeQueue.add(httpContent);
                   
                 } else if (hasContentLength || isWsoc || isHttp10) {
                     ByteBuf nettyBuf = Unpooled.wrappedBuffer(WsByteBufferUtils.asByteArray(buffer));
                     int bytes = nettyBuf.readableBytes();
-                    // ChannelFuture future = nettyChannel.write(nettyBuf);
                     writeQueue.add(nettyBuf);
                     writtenBytes += bytes;
 
@@ -269,15 +268,12 @@ public class NettyTCPWriteRequestContext implements TCPWriteRequestContext {
 
                     ByteBuf nettyBuf = Unpooled.wrappedBuffer(WsByteBufferUtils.asByteArray(buffer));
                     DefaultHttpContent httpContent = new DefaultHttpContent(nettyBuf);
-                    // ChannelFuture future = nettyChannel.write(httpContent);
                     writtenBytes += nettyBuf.readableBytes();
                     writeQueue.add(httpContent);
                 }
             }
 
-            // ChannelFuture flushFuture = nettyChannel.writeAndFlush(Unpooled.EMPTY_BUFFER);
-            // Run all the operations in the event loop
-
+            // Run all the channel operations in the event loop
             nettyChannel.eventLoop().execute(new Runnable() {
                 @Override
                 public void run() {
@@ -308,7 +304,8 @@ public class NettyTCPWriteRequestContext implements TCPWriteRequestContext {
         // ChannelFuture lastWriteFuture = null;
         boolean hasContentLength = nettyChannel.hasAttr(NettyHttpConstants.CONTENT_LENGTH) && Objects.nonNull(nettyChannel.attr(NettyHttpConstants.CONTENT_LENGTH).get());
         // A write queue to run all the write events inside the eventloop to improve performance
-        // TODO Maybe we should see if this writequeue should belong to the class to improve performance?
+        // Maybe we should see if this writequeue should belong to the class to improve performance?
+        // See https://github.com/OpenLiberty/open-liberty/issues/31555
         final Queue<Object> writeQueue = new LinkedList<Object>();
         final ChannelPromise writePromise = nettyChannel.newPromise();
         //check if wsoc
@@ -338,7 +335,6 @@ public class NettyTCPWriteRequestContext implements TCPWriteRequestContext {
                             totalWrittenBytes += buffer.remaining();
                             ByteBuf nettyBuf = Unpooled.wrappedBuffer(WsByteBufferUtils.asByteArray(buffer));
                             HttpContent httpContent = new StreamSpecificHttpContent(Integer.valueOf(this.streamID), Unpooled.wrappedBuffer(WsByteBufferUtils.asByteArray(buffer)));
-                            // lastWriteFuture = this.nettyChannel.write(httpContent);
                             writeQueue.add(httpContent);
 
                         }
@@ -347,35 +343,21 @@ public class NettyTCPWriteRequestContext implements TCPWriteRequestContext {
                                 Tr.debug(this, tc, "Writing async on channel: " + nettyChannel + " which is wsoc? " + isWsoc);
                             }
                             ByteBuf nettyBuf = Unpooled.wrappedBuffer(WsByteBufferUtils.asByteArray(buffer));
-                            // lastWriteFuture = this.nettyChannel.write(nettyBuf); // Write data to the channel
                             totalWrittenBytes += nettyBuf.readableBytes();
                             writeQueue.add(nettyBuf);
                         }
 
                         else {
-                            //ChunkedInput<ByteBuf> chunkedInput = new WsByteBufferChunkedInput(buffer);
-                            //lastWriteFuture = nettyChannel.writeAndFlush(chunkedInput);
-                            //totalWrittenBytes += chunkedInput.length();
-
                             ByteBuf nettyBuf = Unpooled.wrappedBuffer(WsByteBufferUtils.asByteArray(buffer));
                             DefaultHttpContent httpContent = new DefaultHttpContent(nettyBuf);
-
-                            // lastWriteFuture = nettyChannel.write(httpContent);
                             totalWrittenBytes += nettyBuf.readableBytes();
                             writeQueue.add(httpContent);
                         }
-
-//                        ByteBuf nettyBuf = Unpooled.wrappedBuffer(WsByteBufferUtils.asByteArray(buffer));
-//                        lastWriteFuture = nettyChannel.write(nettyBuf);
-//                        totalWrittenBytes += nettyBuf.readableBytes();
                     }
                 }
             }
 
-            // lastWriteFuture = nettyChannel.writeAndFlush(Unpooled.EMPTY_BUFFER);
-
-            // Run all the operations in the event loop
-
+            // Run all channel operations in the event loop
             nettyChannel.eventLoop().execute(new Runnable() {
                 @Override
                 public void run() {

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyRequestMessage.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyRequestMessage.java
@@ -107,7 +107,9 @@ public class NettyRequestMessage extends NettyBaseMessage implements HttpRequest
     private static final byte RIGHT_BRACKET = ']';
 
     /** Request-Resource as a byte[] */
-    private final byte[] myURIBytes = SLASH;
+    private byte[] myURIBytes = SLASH;
+    /** URI as a string */
+    private transient String myURIString = null;
     /** Host string in the request URL (if present) */
     private transient String sUrlHost = null;
     /** Host string parsed from Host header */
@@ -132,6 +134,9 @@ public class NettyRequestMessage extends NettyBaseMessage implements HttpRequest
         this.nettyContext = nettyContext;
 
         parameters = new HashMap<String, String[]>();
+        this.scheme = isc.isSecure() ? SchemeValues.HTTPS : SchemeValues.HTTP;
+        System.out.println("Initializing request with uri: " + request.uri());
+        parseURI(request.uri().getBytes());
         processQuery();
 
         HttpChannelConfig config = isc instanceof HttpInboundServiceContextImpl ? ((HttpInboundServiceContextImpl) isc).getHttpConfig() : null;
@@ -150,7 +155,6 @@ public class NettyRequestMessage extends NettyBaseMessage implements HttpRequest
         // Method check possibly handled by Netty. Need to verify
         // Path check need to add some for ourselves
         if (!getMethod().equalsIgnoreCase(HttpMethod.CONNECT.toString())) {
-            setRequestURI(getRequestURI());
             // Additional verification for url host
             String host = request.uri();
             if (null == host || host.isEmpty()) {
@@ -200,6 +204,47 @@ public class NettyRequestMessage extends NettyBaseMessage implements HttpRequest
         }
         // Need to check if Scheme is also verified by Netty coded or add that ourselves
         // Probably need to add check of authority ourselves as well
+    }
+
+    /**
+     * Parse the URI information out of the input data, along with any query
+     * information found afterwards. If format errors are found, then an
+     * exception is thrown.
+     *
+     * @param data
+     * @throws IllegalArgumentException
+     */
+    private void parseURI(byte[] data) {
+        int start = 0;
+        // at this point, we're parsing /URI [?querystring]
+        if (start >= data.length) {
+            // PK22096 - default to "/" if not found, should have caught empty
+            // string inputs previously (http://host:port is valid)
+            this.myURIBytes = SLASH;
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Defaulting to slash since no URI data found");
+            }
+            return;
+        }
+        int uri_end = data.length;
+        for (int i = start; i < data.length; i++) {
+            // look for the query string marker
+            if ('?' == data[i]) {
+                uri_end = i;
+                break;
+            }
+        }
+        // save off the URI
+        if (start == uri_end) {
+            // no uri found
+            throw new IllegalArgumentException("Missing URI: " + GenericUtils.getEnglishString(data));
+        }
+        if (0 == start && uri_end == data.length) {
+            this.myURIBytes = data;
+        } else {
+            this.myURIBytes = new byte[uri_end - start];
+            System.arraycopy(data, start, this.myURIBytes, 0, this.myURIBytes.length);
+        }
     }
 
     /**
@@ -382,27 +427,14 @@ public class NettyRequestMessage extends NettyBaseMessage implements HttpRequest
     }
 
     @Override
-    @FFDCIgnore({ URISyntaxException.class, IllegalArgumentException.class })
     public String getRequestURI() {
         if (getMethod().equalsIgnoreCase(HttpMethod.CONNECT.toString())) {
             return GenericUtils.getEnglishString(SLASH);
         }
-        try {
-            URI requestUri = new URI(request.uri());
-            // If it works it means we have an absolute URI and not a path
-            return requestUri.getRawPath();
-        } catch (URISyntaxException e) {
-            try {
-                return query.path();
-            } catch (IllegalArgumentException e2) {
-                int queryIndex = request.uri().indexOf('?');
-                if (queryIndex == -1)
-                    return request.uri();
-                return request.uri().substring(0, queryIndex);
-            }
-        } catch (Exception e2) {
-            return request.uri();
+        if (null == this.myURIString) {
+            this.myURIString = GenericUtils.getEnglishString(this.myURIBytes);
         }
+        return this.myURIString;
     }
 
     @Override
@@ -478,17 +510,8 @@ public class NettyRequestMessage extends NettyBaseMessage implements HttpRequest
     }
 
     @Override
-    @FFDCIgnore({ MalformedURLException.class, URISyntaxException.class })
     public void setRequestURI(String uri) {
-        try {
-            URI requestUri = new URL(request.uri()).toURI();
-            // If it works it means we have an absolute URI and not a path
-            setRequestURI(GenericUtils.getEnglishBytes(requestUri.getPath()));
-        } catch (MalformedURLException e) {
-            setRequestURI(GenericUtils.getEnglishBytes(uri));
-        } catch (URISyntaxException e) {
-            setRequestURI(GenericUtils.getEnglishBytes(uri));
-        }
+        setRequestURI(GenericUtils.getEnglishBytes(uri));
     }
 
     @Override
@@ -513,6 +536,7 @@ public class NettyRequestMessage extends NettyBaseMessage implements HttpRequest
             }
             throw new IllegalArgumentException("Invalid uri: " + value);
         }
+        parseURI(uri);
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "setRequestURI: finished parsing " + getRequestURI());
         }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyRequestMessage.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyRequestMessage.java
@@ -135,7 +135,6 @@ public class NettyRequestMessage extends NettyBaseMessage implements HttpRequest
 
         parameters = new HashMap<String, String[]>();
         this.scheme = isc.isSecure() ? SchemeValues.HTTPS : SchemeValues.HTTP;
-        System.out.println("Initializing request with uri: " + request.uri());
         parseURI(request.uri().getBytes());
         processQuery();
 

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyRequestMessage.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyRequestMessage.java
@@ -135,7 +135,6 @@ public class NettyRequestMessage extends NettyBaseMessage implements HttpRequest
 
         parameters = new HashMap<String, String[]>();
         this.scheme = isc.isSecure() ? SchemeValues.HTTPS : SchemeValues.HTTP;
-        parseURI(request.uri().getBytes());
         processQuery();
 
         HttpChannelConfig config = isc instanceof HttpInboundServiceContextImpl ? ((HttpInboundServiceContextImpl) isc).getHttpConfig() : null;
@@ -179,6 +178,7 @@ public class NettyRequestMessage extends NettyBaseMessage implements HttpRequest
             else if (host.length() > 1 && '/' == host.charAt(0) && '/' == host.charAt(1) && getServiceContext().getHttpConfig().isStrictURLFormat()) {
                 start = 2;
             } else {
+                parseURI(host.getBytes(), 0);
                 return;
             }
             // authority is [userinfo@] host [:port] "/URI"
@@ -200,6 +200,7 @@ public class NettyRequestMessage extends NettyBaseMessage implements HttpRequest
                 }
             }
             parseURLHost(host, start, slash_start);
+            parseURI(host.getBytes(), slash_start);
         }
         // Need to check if Scheme is also verified by Netty coded or add that ourselves
         // Probably need to add check of authority ourselves as well
@@ -213,8 +214,7 @@ public class NettyRequestMessage extends NettyBaseMessage implements HttpRequest
      * @param data
      * @throws IllegalArgumentException
      */
-    private void parseURI(byte[] data) {
-        int start = 0;
+    private void parseURI(byte[] data, int start) {
         // at this point, we're parsing /URI [?querystring]
         if (start >= data.length) {
             // PK22096 - default to "/" if not found, should have caught empty
@@ -535,7 +535,7 @@ public class NettyRequestMessage extends NettyBaseMessage implements HttpRequest
             }
             throw new IllegalArgumentException("Invalid uri: " + value);
         }
-        parseURI(uri);
+        parseURI(uri, 0);
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "setRequestURI: finished parsing " + getRequestURI());
         }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/inbound/LibertyHttpObjectAggregator.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/inbound/LibertyHttpObjectAggregator.java
@@ -64,10 +64,6 @@ public class LibertyHttpObjectAggregator extends SimpleChannelInboundHandler<Htt
 
                 if (msg instanceof LastHttpContent) {
                     HttpRequest request = ctx.channel().attr(CURRENT_REQUEST).get();
-
-                    // FullHttpRequest fullRequest = new DefaultFullHttpRequest(request.protocolVersion(), request.method(), request.uri(), content);
-                    // fullRequest.headers().set(request.headers());
-                    // fullRequest.trailingHeaders().set(((LastHttpContent) msg).trailingHeaders());
                     FullHttpRequest fullRequest = new DefaultFullHttpRequest(request.protocolVersion(), request.method(), request.uri(), content, request.headers(), ((LastHttpContent) msg).trailingHeaders());
 
                     ctx.fireChannelRead(fullRequest);

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/inbound/LibertyHttpObjectAggregator.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/inbound/LibertyHttpObjectAggregator.java
@@ -65,9 +65,10 @@ public class LibertyHttpObjectAggregator extends SimpleChannelInboundHandler<Htt
                 if (msg instanceof LastHttpContent) {
                     HttpRequest request = ctx.channel().attr(CURRENT_REQUEST).get();
 
-                    FullHttpRequest fullRequest = new DefaultFullHttpRequest(request.protocolVersion(), request.method(), request.uri(), content);
-                    fullRequest.headers().set(request.headers());
-                    fullRequest.trailingHeaders().set(((LastHttpContent) msg).trailingHeaders());
+                    // FullHttpRequest fullRequest = new DefaultFullHttpRequest(request.protocolVersion(), request.method(), request.uri(), content);
+                    // fullRequest.headers().set(request.headers());
+                    // fullRequest.trailingHeaders().set(((LastHttpContent) msg).trailingHeaders());
+                    FullHttpRequest fullRequest = new DefaultFullHttpRequest(request.protocolVersion(), request.method(), request.uri(), content, request.headers(), ((LastHttpContent) msg).trailingHeaders());
 
                     ctx.fireChannelRead(fullRequest);
 

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/outbound/HeaderHandler.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/outbound/HeaderHandler.java
@@ -64,7 +64,7 @@ public class HeaderHandler {
         if (!headers.contains(HttpHeaderKeys.HDR_DATE.getName())) {
 
             headers.set(HttpHeaderKeys.HDR_DATE.getName(),
-                        new String(HttpDispatcher.getDateFormatter().getRFC1123TimeAsBytes(config.getDateHeaderRange()), StandardCharsets.UTF_8));
+                            HttpDispatcher.getDateFormatter().getRFC1123TimeAsBytes(config.getDateHeaderRange()));
         }
 
         // If HTTP 1.0 remove the Transfer-Encoding header if it exists.
@@ -91,7 +91,7 @@ public class HeaderHandler {
         } else if (!headers.contains(HttpHeaderKeys.HDR_SERVER.getName())) {
             byte[] serverHeader = config.getServerHeaderValue();
             if (Objects.nonNull(serverHeader)) {
-                headers.set(HttpHeaderKeys.HDR_SERVER.getName(), new String(serverHeader, StandardCharsets.UTF_8));
+                headers.set(HttpHeaderKeys.HDR_SERVER.getName(), serverHeader);
                 Tr.debug(tc, "Adding the Server header value: " + headers.get(HttpHeaderKeys.HDR_SERVER.getName()));
             }
 

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/outbound/HeaderHandler.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/outbound/HeaderHandler.java
@@ -62,9 +62,11 @@ public class HeaderHandler {
         }
 
         if (!headers.contains(HttpHeaderKeys.HDR_DATE.getName())) {
-
+            byte[] date = HttpDispatcher.getDateFormatter().getRFC1123TimeAsBytes(config.getDateHeaderRange());
+            System.out.println("Setting date!! " + date);
             headers.set(HttpHeaderKeys.HDR_DATE.getName(),
-                            HttpDispatcher.getDateFormatter().getRFC1123TimeAsBytes(config.getDateHeaderRange()));
+                            new String(date, StandardCharsets.UTF_8));
+            System.out.println("Date set: " + headers.get(HttpHeaderKeys.HDR_DATE.getName()));
         }
 
         // If HTTP 1.0 remove the Transfer-Encoding header if it exists.
@@ -91,7 +93,7 @@ public class HeaderHandler {
         } else if (!headers.contains(HttpHeaderKeys.HDR_SERVER.getName())) {
             byte[] serverHeader = config.getServerHeaderValue();
             if (Objects.nonNull(serverHeader)) {
-                headers.set(HttpHeaderKeys.HDR_SERVER.getName(), serverHeader);
+                headers.set(HttpHeaderKeys.HDR_SERVER.getName(), new String(serverHeader, StandardCharsets.UTF_8));
                 Tr.debug(tc, "Adding the Server header value: " + headers.get(HttpHeaderKeys.HDR_SERVER.getName()));
             }
 

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/outbound/HeaderHandler.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/outbound/HeaderHandler.java
@@ -63,10 +63,8 @@ public class HeaderHandler {
 
         if (!headers.contains(HttpHeaderKeys.HDR_DATE.getName())) {
             byte[] date = HttpDispatcher.getDateFormatter().getRFC1123TimeAsBytes(config.getDateHeaderRange());
-            System.out.println("Setting date!! " + date);
             headers.set(HttpHeaderKeys.HDR_DATE.getName(),
                             new String(date, StandardCharsets.UTF_8));
-            System.out.println("Date set: " + headers.get(HttpHeaderKeys.HDR_DATE.getName()));
         }
 
         // If HTTP 1.0 remove the Transfer-Encoding header if it exists.


### PR DESCRIPTION
Updated Netty parts for various performance improvements
- Disabled Netty response validation due to zero migration using our own validation as used in Legacy
- Updated TCP write request context to combine write calls into one single call to the Netty executor
- Limited the amount of execute calls for the Liberty executor
- Switched Full HTTP Request Netty object creation to not set headers and trailers after but include them in the constructor
- Switched URI parsing to cache the results of the URI and reuse instead of multiple calls to URI object