### PR TITLE
Throw IOException on closed connections during syncWrite

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpServiceContextImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpServiceContextImpl.java
@@ -3686,6 +3686,9 @@ public abstract class HttpServiceContextImpl implements HttpServiceContext, FFDC
 
             getTSC().getWriteInterface().setBuffers(writeBuffers);
             try {
+                if(!nettyContext.channel().isOpen()){
+                    throw new IOException("Attempted to write on a closed Netty channel");
+                }
                 getTSC().getWriteInterface().write(TCPWriteRequestContext.WRITE_ALL_DATA, null, false, getWriteTimeout());
             } finally {
                 // 457369 - disconnect write buffers in TCP when done


### PR DESCRIPTION
- [x] Considered risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes)
- [x] Resolved Issues: Fixes #FILLMEIN... (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions)
- [x] Resolved external Known Issues (including APARS): Fixes #FILLMEIN...

This change is related to the Jakarta 3.1 TCK closeTest. We saw the test failing because it was expecting to find the channel closed, but it was reported as open. For performance, we moved all sync writes to be async. However, in the previous implementation, if any Exception happened while the write was in transit, the channel would receive an IOException. Since we have made it non-blocking, the write was being issued and control handed immediately without throwing an exception if the channel was already closed. While the Netty channel would eventually close within the pipeline when the IO was attempted, since control had already been handed back to the HTTP transport, it thought it was still open. 

As such, we check now if the channel isOpen, and throw an exception if it's not before even attempting to send the IO down the pipeline. 